### PR TITLE
Split makie support into a separate JlCxx module so it can be wrapped by a separate package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+.cache/
+# Might want to commit this, but for now im just using it locally for a workaround on Linux.
+.clangd

--- a/makie_viewport.cpp
+++ b/makie_viewport.cpp
@@ -5,6 +5,7 @@
 
 #include <QOpenGLContext>
 #include <QQuickWindow>
+#include <julia.h>
 
 namespace qmlwrap
 {
@@ -32,13 +33,17 @@ private:
 
 jl_module_t* get_makie_support_module()
 {
-  jl_value_t* mod = jl_get_global(MakieViewport::m_qml_mod, jl_symbol("MakieSupport"));
-  if(mod == nullptr || !jl_is_module(mod))
+  // MakieViewport::m_qml_mod is set when initializing the Julia module `QtMakie`,
+  // corresponding to `JLCXX_MODULE define_julia_module_makie` in `wrap_qml.cpp`.
+  jl_module_t* mod = MakieViewport::m_qml_mod;
+
+  // If `mod` is not initialized, you have not loaded the Julia module.
+  if(mod == nullptr)
   {
-    throw std::runtime_error("Makie is not loaded, did you forget \"Using Makie\" in your Julia file?");
+    throw std::runtime_error("Makie Support not initialized. Have you loaded QtMakie?");
   }
-  
-  return (jl_module_t*)mod;
+
+  return mod;
 }
 
 /// Takes care of loading the MakieSupport Julia module

--- a/wrap_qml.cpp
+++ b/wrap_qml.cpp
@@ -247,7 +247,7 @@ struct WrapQtIterator
     using WrappedT = typename TypeWrapperT::type;
     using KeyT = typename WrappedT::key_type;
     using ValueT = typename WrappedT::value_type;
-    
+
     wrapped.method("iteratornext", [] (WrappedT it) -> WrappedT { ++(it.value); return it; });
     wrapped.method("iteratorkey", [] (WrappedT it) -> KeyT { validate_iterator(it); return it.value.key();} );
     wrapped.method("iteratorvalue", [] (WrappedT it) -> ValueT& { validate_iterator(it); return it.value.value(); } );
@@ -282,6 +282,12 @@ struct WrapQtAssociativeContainer
 
 }
 
+JLCXX_MODULE define_julia_module_makie(jlcxx::Module& qml_module)
+{
+    using namespace jlcxx;
+    qmlwrap::MakieViewport::m_qml_mod = qml_module.julia_module();
+}
+
 JLCXX_MODULE define_julia_module(jlcxx::Module& qml_module)
 {
   using namespace jlcxx;
@@ -290,8 +296,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& qml_module)
   qmlwrap::JuliaFunction::m_qml_mod = qml_module.julia_module();
   qmlwrap::ApplicationManager::m_qml_mod = qml_module.julia_module();
   qmlwrap::JuliaItemModel::m_qml_mod = qml_module.julia_module();
-  qmlwrap::MakieViewport::m_qml_mod = qml_module.julia_module();
-  
+
   // Enums
   qml_module.add_bits<Qt::Orientation>("Orientation", jlcxx::julia_type("CppEnum"));
   qml_module.set_const("Horizontal", Qt::Horizontal);
@@ -390,7 +395,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& qml_module)
     .constructor<QString>()
     .method("toString", [] (const QUrl& url) { return url.toString(); });
   qml_module.method("QUrlFromLocalFile", QUrl::fromLocalFile);
-  
+
   auto qvar_type = qml_module.add_type<QVariant>("QVariant");
   qvar_type.method("toString", &QVariant::toString);
 
@@ -413,7 +418,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& qml_module)
     .apply<qmlwrap::QHashIteratorWrapper<int, QByteArray>>(qmlwrap::WrapQtIterator());
   qml_module.add_type<Parametric<TypeVar<1>,TypeVar<2>>>("QHash", julia_type("AbstractDict"))
     .apply<QHash<int, QByteArray>>(qmlwrap::WrapQtAssociativeContainer<qmlwrap::QHashIteratorWrapper>());
-  
+
   qml_module.add_type<QQmlPropertyMap>("QQmlPropertyMap", julia_base_type<QObject>())
     .constructor<QObject *>(jlcxx::finalize_policy::no)
     .method("clear", &QQmlPropertyMap::clear)
@@ -439,7 +444,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& qml_module)
   jlcxx::stl::apply_stl<QVariant>(qml_module);
 
   qml_module.method("make_qvariant_map", [] ()
-  { 
+  {
     QVariantMap m;
     m[QString("test")] = QVariant::fromValue(5);
     return QVariant::fromValue(m);


### PR DESCRIPTION
This is probably not quite ready for a merge, but I'm starting a PR so we have a place to discuss where to go from here, and for visibility in case someone wants to play around with it or help out.

This PR supports https://github.com/JuliaGraphics/QML.jl/pull/207.

I opted to keep the C++ code backing QMLMakie in here for now. In the long term it might be interesting to separate it into its own JLL if it becomes huge, but I couldn't quite figure out the logistics of making a new JLL that links to this one so the Makie component can extend the generic OpenGL component.